### PR TITLE
feat: configurable minimum scrobble length

### DIFF
--- a/src/services/lastfmService.ts
+++ b/src/services/lastfmService.ts
@@ -17,6 +17,17 @@ interface LastfmConfig {
     sessionKey: string;
     username: string;
     enabled: boolean;
+    minScrobbleLen: number;
+}
+
+/**
+ * last.fm scrobble threshold: a track is eligible once it's longer than
+ * minLen; it then scrobbles at half its duration or 4 minutes, whichever
+ * comes first. returns null when the track should never scrobble.
+ */
+export function scrobbleThreshold(duration: number, minLen: number): number | null {
+    if (duration <= minLen) return null;
+    return Math.min(duration / 2, 240);
 }
 
 export class LastfmService {
@@ -30,12 +41,17 @@ export class LastfmService {
 
     private cfg(): LastfmConfig {
         const raw = (this.store.get('lastfm') as Partial<LastfmConfig>) || {};
+        const m = Number(raw.minScrobbleLen);
         return {
             apiKey: raw.apiKey || '',
             apiSecret: raw.apiSecret || '',
             sessionKey: raw.sessionKey || '',
             username: raw.username || '',
             enabled: raw.enabled !== false,
+            minScrobbleLen:
+                raw.minScrobbleLen === undefined || !Number.isFinite(m)
+                    ? 30
+                    : Math.max(0, Math.min(30, Math.round(m))),
         };
     }
 
@@ -176,9 +192,9 @@ export class LastfmService {
         }
         this.lastPos = track.position;
         if (this.scrobbled) return;
-        // last.fm rule: half track or 4 mins whichever comes first.
-        const threshold = track.duration > 30 ? Math.min(track.duration / 2, 240) : 0;
-        if (!threshold || track.position < threshold) return;
+        const minLen = this.cfg().minScrobbleLen;
+        const threshold = scrobbleThreshold(track.duration, minLen);
+        if (threshold === null || track.position < threshold) return;
         this.scrobbled = true;
 
         const c = this.cfg();

--- a/src/services/lastfmService.ts
+++ b/src/services/lastfmService.ts
@@ -49,7 +49,9 @@ export class LastfmService {
             username: raw.username || '',
             enabled: raw.enabled !== false,
             minScrobbleLen:
-                raw.minScrobbleLen === undefined || !Number.isFinite(m)
+                raw.minScrobbleLen === undefined ||
+                raw.minScrobbleLen === null ||
+                !Number.isFinite(m)
                     ? 30
                     : Math.max(0, Math.min(30, Math.round(m))),
         };

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -327,7 +327,7 @@
             $('apiKey').value = lfm.apiKey || '';
             $('apiSecret').value = lfm.apiSecret || '';
             $('lfmEnabled').checked = lfm.enabled !== false;
-            $('minScrobbleLen').value = lfm.minScrobbleLen === undefined ? 30 : lfm.minScrobbleLen;
+            $('minScrobbleLen').value = lfm.minScrobbleLen == null ? 30 : lfm.minScrobbleLen;
             $('discordEnabled').checked = s.discordEnabled !== false;
             $('discordClientId').value = s.discordClientId || '';
             const dOpts = s.discordOpts || {};

--- a/src/settings/settings.html
+++ b/src/settings/settings.html
@@ -36,7 +36,7 @@
         .section { border: 1px solid #2a2e30; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
         .section h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .06em; color: #9a968e; margin-bottom: 12px; }
         label { display: block; font-size: 11px; color: #fff; margin: 10px 0 4px; }
-        input[type="text"], input[type="password"] {
+        input[type="text"], input[type="password"], input[type="number"] {
             width: 100%; background: #121415; border: 1px solid #2a2e30; border-radius: 5px;
             color: #e8e6e3; padding: 8px 10px; font-size: 12px;
         }
@@ -83,6 +83,11 @@
         <div class="row" style="margin-top:12px;">
             <label class="toggle" style="margin:0;"><input type="checkbox" id="lfmEnabled"> Enable scrobbling</label>
             <span id="lfmUser" class="status"></span>
+        </div>
+        <label style="margin-top:12px;">Minimum track length to scrobble (seconds)</label>
+        <div class="row" style="gap:8px;margin-top:2px;">
+            <input type="number" id="minScrobbleLen" min="0" max="30" step="1" style="width:90px;" autocomplete="off">
+            <span class="hint" style="flex:1;margin:0;">tracks shorter than this are never scrobbled; 0 scrobbles everything at half its length. last.fm may ignore very short scrobbles.</span>
         </div>
         <div class="row">
             <button id="btnConnect">Connect account</button>
@@ -322,6 +327,7 @@
             $('apiKey').value = lfm.apiKey || '';
             $('apiSecret').value = lfm.apiSecret || '';
             $('lfmEnabled').checked = lfm.enabled !== false;
+            $('minScrobbleLen').value = lfm.minScrobbleLen === undefined ? 30 : lfm.minScrobbleLen;
             $('discordEnabled').checked = s.discordEnabled !== false;
             $('discordClientId').value = s.discordClientId || '';
             const dOpts = s.discordOpts || {};
@@ -377,7 +383,13 @@
         async function persist() {
             if (!ipcRenderer) return { ok: false, error: 'no bridge' };
             return ipcRenderer.invoke('settings:save', {
-                lastfm: { apiKey: $('apiKey').value.trim(), apiSecret: $('apiSecret').value.trim(), enabled: $('lfmEnabled').checked },
+                lastfm: { apiKey: $('apiKey').value.trim(), apiSecret: $('apiSecret').value.trim(), enabled: $('lfmEnabled').checked,
+                    minScrobbleLen: (() => {
+                        const raw = $('minScrobbleLen').value.trim();
+                        const v = raw === '' ? 30 : Number(raw);
+                        return Number.isFinite(v) ? Math.min(Math.max(Math.round(v), 0), 30) : 30;
+                    })()
+                },
                 discordEnabled: $('discordEnabled').checked,
                 discordClientId: $('discordClientId').value.trim(),
                 discordOpts: { showWhenPaused: $('dOptPaused').checked },


### PR DESCRIPTION
Adds a configurable minimum track length for last.fm scrobbling. You can now scrobble tracks shorter than 30 seconds by lowering the minimum in Settings, under Last.fm Scrobbling. The default of 30 keeps the current behavior exactly, so nothing changes unless you change the setting.